### PR TITLE
#1 Feature: 장시간 회의 녹화 처리 기능 구현

### DIFF
--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -1,14 +1,18 @@
 """
-Meeting audio transcription using OpenAI GPT-4o mini Transcribe.
+Meeting audio transcription using OpenAI GPT-4o Transcribe.
 
 Converts audio to raw text only. Meeting summarization and analysis
 is handled by Claude in the doc-orchestrator skill.
+
+Supports long audio files by automatically chunking them into segments
+under the API's 1400-second limit.
 
 Usage:
     python scripts/transcribe.py <audio_file_path> <output_path>
 
 Requirements:
-    pip install openai
+    - ffmpeg (for audio duration detection and chunking)
+    - pip install openai
 
 Environment:
     OPENAI_API_KEY must be set
@@ -17,6 +21,9 @@ Environment:
 import sys
 import json
 import os
+import subprocess
+import tempfile
+import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -28,10 +35,72 @@ except ImportError:
 
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".wav", ".m4a", ".webm", ".ogg", ".flac"}
+MAX_DURATION_SECONDS = 1300  # Leave buffer below 1400s API limit
+
+
+def get_audio_duration(audio_path: Path) -> float:
+    """Get audio duration in seconds using ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            str(audio_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {result.stderr}")
+    return float(result.stdout.strip())
+
+
+def split_audio(audio_path: Path, chunk_duration: int, output_dir: Path) -> list[Path]:
+    """Split audio file into chunks using ffmpeg."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use same extension as input for compatibility
+    ext = audio_path.suffix
+    output_pattern = output_dir / f"chunk_%03d{ext}"
+
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-i", str(audio_path),
+            "-f", "segment",
+            "-segment_time", str(chunk_duration),
+            "-c", "copy",  # No re-encoding, fast
+            "-reset_timestamps", "1",
+            str(output_pattern),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ffmpeg split failed: {result.stderr}")
+
+    # Return sorted list of chunk files
+    chunks = sorted(output_dir.glob(f"chunk_*{ext}"))
+    return chunks
+
+
+def transcribe_single(client: OpenAI, audio_path: Path) -> str:
+    """Transcribe a single audio file."""
+    with open(audio_path, "rb") as audio_file:
+        response = client.audio.transcriptions.create(
+            model="gpt-4o-transcribe",
+            file=audio_file,
+            response_format="json",
+        )
+    return response.text
 
 
 def transcribe(audio_file_path: str) -> dict:
-    """Transcribe meeting audio using GPT-4o mini Transcribe."""
+    """Transcribe meeting audio using GPT-4o Transcribe.
+
+    Automatically chunks long audio files that exceed the API limit.
+    """
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         print("Error: OPENAI_API_KEY environment variable not set")
@@ -50,18 +119,51 @@ def transcribe(audio_file_path: str) -> dict:
 
     client = OpenAI(api_key=api_key)
 
-    with open(path, "rb") as audio_file:
-        response = client.audio.transcriptions.create(
-            model="gpt-4o-transcribe",
-            file=audio_file,
-            response_format="json",
-        )
+    # Check duration
+    duration = get_audio_duration(path)
+    print(f"Audio duration: {duration:.1f} seconds ({duration/60:.1f} minutes)")
 
-    return {
-        "transcript": response.text,
+    if duration <= MAX_DURATION_SECONDS:
+        # Short audio - transcribe directly
+        transcript = transcribe_single(client, path)
+        chunks_info = None
+    else:
+        # Long audio - split and transcribe chunks
+        num_chunks = int(duration // MAX_DURATION_SECONDS) + 1
+        print(f"Audio exceeds {MAX_DURATION_SECONDS}s limit, splitting into {num_chunks} chunks...")
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="transcribe_"))
+        try:
+            chunks = split_audio(path, MAX_DURATION_SECONDS, temp_dir)
+            print(f"Created {len(chunks)} chunks")
+
+            transcripts = []
+            for i, chunk in enumerate(chunks):
+                print(f"Transcribing chunk {i+1}/{len(chunks)}...")
+                chunk_transcript = transcribe_single(client, chunk)
+                transcripts.append(chunk_transcript)
+
+            # Join transcripts with spacing
+            transcript = "\n\n".join(transcripts)
+            chunks_info = {
+                "count": len(chunks),
+                "chunk_duration_seconds": MAX_DURATION_SECONDS,
+            }
+        finally:
+            # Clean up temp directory
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    result = {
+        "transcript": transcript,
         "source_file": audio_file_path,
+        "duration_seconds": duration,
         "processed_at": datetime.now().isoformat(),
     }
+
+    if chunks_info:
+        result["chunks"] = chunks_info
+
+    return result
 
 
 def main():


### PR DESCRIPTION
close #1 
---
- 장시간 회의록의 경우, open api transcribe api의 limitation으로 처리를 못하는 문제가 있었습니다. 
- 해당 문제를 해결하기 위해, 오디오를 chunk로 잘라서 처리합니다. 
---
- 컨플루언스 문서를 업데이트시, partial update를 support하지 않아서 전체를 덮어쓰다보니 지라 티켓 링크가 깨지는 경우가 있었습니다. 
- 해당 문제의 원인은 읽어올때 markdown 형식으로 가져오면서 링크가 깨지는 것이었습니다. 
- 해결하기 위해 skill에 markdown 형식으로 가져오지 말고 전체를 잘 보존해서 가져오도록 제약사항을 추가했습니다. 
--- 
- 컨플루언스의 mcp에서 지원하지 않는 partial update, version change 기능을 구현할 수 있을지 검토해보겠습니다. 